### PR TITLE
Add optixHello example

### DIFF
--- a/examples/cuda/hello.cu
+++ b/examples/cuda/hello.cu
@@ -1,0 +1,45 @@
+//
+// Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of NVIDIA CORPORATION nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+#include <optix.h>
+
+#include "hello.h"
+#include "helpers.h"
+
+extern "C" {
+__constant__ Params params;
+}
+
+extern "C"
+__global__ void __raygen__draw_solid_color()
+{
+    uint3 launch_index = optixGetLaunchIndex();
+    RayGenData* rtData = (RayGenData*)optixGetSbtDataPointer();
+    params.image[launch_index.y * params.image_width + launch_index.x] =
+        make_color( make_float3( rtData->r, rtData->g, rtData->b ) );
+}

--- a/examples/cuda/hello.h
+++ b/examples/cuda/hello.h
@@ -1,0 +1,38 @@
+//
+// Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of NVIDIA CORPORATION nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+struct Params
+{
+    uchar4* image;
+    unsigned int image_width;
+};
+
+struct RayGenData
+{
+    float r,g,b;
+};

--- a/examples/hello.py
+++ b/examples/hello.py
@@ -1,0 +1,86 @@
+import optix as ox
+import cupy as cp
+import numpy as np
+from PIL import Image, ImageOps
+import logging
+import sys
+logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
+log = logging.getLogger()
+
+def create_module(ctx, pipeline_opts):
+    compile_opts = ox.ModuleCompileOptions(debug_level=ox.CompileDebugLevel.LINEINFO)
+    module = ox.Module(ctx, 'cuda/hello.cu', compile_opts, pipeline_opts)
+    return module
+
+
+def create_program_groups(ctx, module):
+    raygen_grp = ox.ProgramGroup.create_raygen(ctx, module, "__raygen__draw_solid_color")
+    miss_grp = ox.ProgramGroup.create_miss(ctx, None, None)
+    return raygen_grp, miss_grp
+
+
+def create_pipeline(ctx, program_grps, pipeline_options):
+    link_opts = ox.PipelineLinkOptions(max_trace_depth=0, debug_level=ox.CompileDebugLevel.FULL)
+
+    pipeline = ox.Pipeline(ctx, compile_options=pipeline_options, link_options=link_opts,
+            program_groups=program_grps, max_traversable_graph_depth=1)
+
+    pipeline.compute_stack_sizes(0,  # max_trace_depth
+                                 0,  # max_cc_depth
+                                 0)  # max_dc_depth
+    return pipeline
+
+
+def create_sbt(program_grps):
+    raygen_grp, miss_grp = program_grps
+
+    raygen_sbt = ox.SbtRecord(raygen_grp, names=('r','g','b'), formats=('f4',)*3)
+    raygen_sbt['r'] = 0.462
+    raygen_sbt['g'] = 0.725
+    raygen_sbt['b'] = 0.0
+
+    miss_sbt = ox.SbtRecord(miss_grp)
+
+    sbt = ox.ShaderBindingTable(raygen_record=raygen_sbt, miss_records=miss_sbt)
+
+    return sbt
+
+
+def launch_pipeline(pipeline : ox.Pipeline, sbt):
+    width = 512
+    height = 384
+
+    output_image = cp.empty(shape=(height,width,4), dtype=np.uint8)
+
+    params = ox.LaunchParamsRecord(names=('image', 'image_width'),
+                                   formats=('u8', 'u4'))
+    params['image'] = output_image.data.ptr
+    params['image_width'] = width
+
+    stream = cp.cuda.Stream()
+
+    pipeline.launch(sbt, dimensions=(width, height), params=params, stream=stream)
+
+    stream.synchronize()
+
+    return cp.asnumpy(output_image)
+
+
+if __name__ == "__main__":
+    logger = ox.Logger(log)
+    ctx = ox.DeviceContext(validation_mode=True, log_callback_function=logger, log_callback_level=4)
+    ctx.cache_enabled = False
+
+    tgf = ox.TraversableGraphFlags
+    pipeline_options = ox.PipelineCompileOptions(traversable_graph_flags=tgf.ALLOW_SINGLE_LEVEL_INSTANCING | tgf.ALLOW_SINGLE_GAS,
+                                                 num_payload_values=0,
+                                                 num_attribute_values=0,
+                                                 exception_flags=ox.ExceptionFlags.NONE,
+                                                 pipeline_launch_params_variable_name="params")
+
+    module = create_module(ctx, pipeline_options)
+    program_grps = create_program_groups(ctx, module)
+    pipeline = create_pipeline(ctx, program_grps, pipeline_options)
+    sbt = create_sbt(program_grps)
+    img = launch_pipeline(pipeline, sbt)
+    Image.fromarray(img, 'RGBA').show()


### PR DESCRIPTION
Hello,

thanks for your amazing work, your wrapper works flawlessly on my machine (at least for the two provided examples by using cuda 11.4, optix 7.3 on ubuntu 20.04).

Here is the implementation of the OptixHello example, it is not much, but I needed to start somewhere.

Do you have any plan to support interactive examples ? We could use a high-level python opengl-based API coupled with OpenGL/CUDA buffer interop. Apparently CUDA/OpenGL interop is [not yet available in cupy](https://github.com/cupy/cupy/issues/5711). Of course, we could map the cupy buffer by using directly the raw pointer, but last time I checked, the [cuda python low-level bindings](https://github.com/NVIDIA/cuda-python) did not wrap all the required interop functions.