### PR TITLE
Windows build support.

### DIFF
--- a/optix/optix_includes.h
+++ b/optix/optix_includes.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#if defined(_MSC_VER)
+#define NOMINMAX
+#endif
+
 #include <optix.h>
 #include <optix_stubs.h>
 #include <optix_function_table_definition.h>

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 from setuptools import setup, Extension, find_packages
 from Cython.Build import cythonize
 import re
+import os
 from pathlib import Path
 
 
@@ -49,8 +50,13 @@ cython_compile_env = {
     '_OPTIX_VERSION_MICRO': optix_version_micro
 }
 
+libraries=[]
+if os.name == 'nt':
+    # OptiX uses some Windows Registry API(e.g. RegCloseKey)
+    libraries.append('advapi32')
+
 extensions = [Extension("*", ["optix/*.pyx"],
-                        include_dirs=[cuda_include_path, optix_include_path])]
+                        include_dirs=[cuda_include_path, optix_include_path], libraries=libraries)]
 extensions = cythonize(extensions, language_level="3",
                         compile_time_env=cython_compile_env, build_dir="build")
 


### PR DESCRIPTION
Thank you for great library!

This PR supports building python-optix on Windows.

I have confirmed every scripts in `examples` works well on Windows.
 
Changes are:

- Define NOMINMAX for MSVC(otherwise comilation fails for `std::max` used in OptiX header)
- Link with advapi32(OptiX uses some Windows Registry API)

Build environment

- Windows11 64bit
- Conda python 3.8
- MSVC(VS2019)
